### PR TITLE
encoding指定

### DIFF
--- a/pycon.jp/pyconjp.py
+++ b/pycon.jp/pyconjp.py
@@ -13,7 +13,7 @@ TARGET_URL = 'https://pycon.jp/2015/ja/schedule/tutorials/list/'
 
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser()
-    parser.add_argument('output', type=argparse.FileType('w'))
+    parser.add_argument('output', type=argparse.FileType('w', encoding='utf-8'))
     parser.add_argument('-f', '--format', default='json', choices=['json', 'csv'])
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
encoding='utf-8' を指定しないと、日本語Windowsでは'cp932'でファイルを開かれてしまうので、ちゃんと指定する。